### PR TITLE
Add fisher namespace for plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ zplug "simnalamburt/shellder"
 # fish
 omf install shellder
 
-fisher shellder
+fisher simnalamburt/shellder
 ```
 
 #### Fonts


### PR DESCRIPTION
This PR prevents `fisher` plugin error installation:

``` sh
~> fisherman version 2.10.0
~> fisher shellder
Installing 1 plugin/s
! Fetch shellder github.com/fisherman/shellder
! There was an error installing shellder or more plugin/s.
Try using a namespace before the plugin name: owner/shellder
```

Adding owner namespace:

``` sh
~> fisher simnalamburt/shellder
Installing 1 plugin/s
OK Fetch shellder github.com/simnalamburt/shellder
Done in 1s 88ms
~ 
```
