### PR TITLE
fix deprecated use of available to type -q

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -237,8 +237,7 @@ function prompt_status -d "the symbols for a non zero exit status, root and back
     end
 end
 
-# `type -q` equivalent for fish<2.0.0
-function available -a name -d "Check if a function or program is available."
+function type -q -a name -d "Check if a function or program is type -q."
   type "$name" ^/dev/null >&2
 end
 
@@ -252,8 +251,8 @@ function fish_prompt
   prompt_virtual_env
   prompt_user
   prompt_dir
-  available hg;  and prompt_hg
-  available git; and prompt_git
-  available svn; and prompt_svn
+  type -q hg;  and prompt_hg
+  type -q git; and prompt_git
+  type -q svn; and prompt_svn
   prompt_finish
 end


### PR DESCRIPTION

fix

function available is deprecated and will be removed soon.
called on line 255 of file ~/.config/fish/functions/fish_prompt.fish
