### PR TITLE
Add optional shrink-path feature

### DIFF
--- a/shellder.zsh-theme
+++ b/shellder.zsh-theme
@@ -1,5 +1,5 @@
 # vim:ft=zsh ts=2 sw=2 sts=2
- 
+
 #
 # Segment drawing
 #
@@ -170,7 +170,7 @@ prompt_hg() {
 
 # Dir: current working directory
 prompt_dir() {
-  prompt_segment $SHELLDER_DIRECTORY_BG $SHELLDER_DIRECTORY_FG '%~'
+  prompt_segment $SHELLDER_DIRECTORY_BG $SHELLDER_DIRECTORY_FG $(shrink_path -f)
 }
 
 # Virtualenv: current working virtualenv

--- a/shellder.zsh-theme
+++ b/shellder.zsh-theme
@@ -170,7 +170,13 @@ prompt_hg() {
 
 # Dir: current working directory
 prompt_dir() {
-  prompt_segment $SHELLDER_DIRECTORY_BG $SHELLDER_DIRECTORY_FG $(shrink_path -f)
+  local dir
+  if type shrink_path &> /dev/null; then
+    dir=$(shrink_path -f)
+  else
+    dir='%~'
+  fi
+  prompt_segment $SHELLDER_DIRECTORY_BG $SHELLDER_DIRECTORY_FG $dir
 }
 
 # Virtualenv: current working virtualenv


### PR DESCRIPTION
If [shrink-path](https://github.com/robbyrussell/oh-my-zsh/tree/master/plugins/shrink-path) exists, use it instead of default path indicator.