### PR TITLE
Faster existance checking

### DIFF
--- a/shellder.zsh-theme
+++ b/shellder.zsh-theme
@@ -171,7 +171,7 @@ prompt_hg() {
 # Dir: current working directory
 prompt_dir() {
   local dir
-  if type shrink_path &> /dev/null; then
+  if (( $+functions[shrink_path] )); then
     dir=$(shrink_path -f)
   else
     dir='%~'


### PR DESCRIPTION
According to [this article](https://www.topbug.net/blog/2016/10/11/speed-test-check-the-existence-of-a-command-in-bash-and-zsh/), `$+functions[foo]` is much faster than `type foo > /dev/null` in zsh.