### PR TITLE
Updates on path display

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ github:
 - simnalamburt/shellder
 ```
 
+&nbsp;
+
+Configuration
+-------
+You can turn off Fish-like path shrinking by adding the following to your `~/.zshrc`:
+
+```zsh
+# ~/.zshrc
+export SHELLDER_KEEP_PATH=1
+```
+
+&nbsp;
+
 ## Fonts
 You'll need a powerline patched font. If you don't have one, download one or
 patch some fonts on you own.

--- a/shellder.zsh-theme
+++ b/shellder.zsh-theme
@@ -201,13 +201,28 @@ prompt_hg() {
   fi
 }
 
+# Turn '/some/quite/very/long/path' into '/s/q/v/l/path'
+function shrinked_path() {
+  local paths=(${PWD/$HOME/\~}) 'cur_dir'
+  paths=(${(s:/:)paths})
+  for idx in {1..$#paths}; do
+    if [[ idx -lt $#paths ]]; then
+      cur_dir+="${paths[idx]:0:1}"
+    else
+      cur_dir+="${paths[idx]}"
+    fi
+    cur_dir+='/'
+  done
+  echo "${cur_dir: :-1}"
+}
+
 # Dir: current working directory
 prompt_dir() {
   local dir
-  if (( $+functions[shrink_path] )); then
-    dir=$(shrink_path -f)
-  else
+  if [[ -n $SHELLDER_KEEP_PATH ]]; then
     dir='%~'
+  else
+    dir=$(shrinked_path)
   fi
   prompt_segment "$SHELLDER_DIRECTORY_BG" "$SHELLDER_DIRECTORY_FG" "$dir"
 }
@@ -247,5 +262,4 @@ build_prompt() {
 }
 
 export VIRTUAL_ENV_DISABLE_PROMPT='true'
-setopt prompt_subst
 PROMPT='%{%f%b%k%}$(build_prompt) '


### PR DESCRIPTION
@simnalamburt I disliked that my path is always long across the entire terminal, so I wanted it shrinked like in Fish. But then I found that `shrink_path` is actually there, but just that thing never worked for me. So I decided to remove `shrink_path` plugin (which is still a plugin, means optional and is huge function, while can be ten times simpler), and so I decided to make it on my own manually.

I also highlighted virtual env with its own blue segment at the beginning of the prompt.

Check it out! :wink: 